### PR TITLE
Fix: Address WordPress.org review feedback

### DIFF
--- a/a-flek90-tool-floating-field.php
+++ b/a-flek90-tool-floating-field.php
@@ -19,12 +19,11 @@ if (!defined('ABSPATH')) {
 }
 
 // Initialize the plugin
-class A_FleK90_Tool_Floating_Field {
+class AFTFF_Floating_Field_Plugin {
     private $plugin_version = '5.6';
     private $settings_page_hook_suffix; // Hook suffix for the main settings page (now tabbed)
 
     public function __construct() {
-        add_action('plugins_loaded', [$this, 'load_textdomain']); // Added for localization
         add_action('admin_menu', [$this, 'add_admin_menu']);
         add_action('wp_enqueue_scripts', [$this, 'enqueue_scripts']);
         add_action('wp_footer', [$this, 'render_floating_field']);
@@ -38,14 +37,6 @@ class A_FleK90_Tool_Floating_Field {
         // Add settings link to plugin list
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), [$this, 'add_settings_link_to_plugin_list']);
         // Customizer hooks removed
-    }
-
-    public function load_textdomain() { // Added for localization
-        load_plugin_textdomain(
-            'a-flek90-tool-floating-field',
-            false,
-            dirname(plugin_basename(__FILE__)) . '/languages/'
-        );
     }
 
     private static function get_position_choices() {
@@ -62,7 +53,18 @@ class A_FleK90_Tool_Floating_Field {
         ];
     }
 
+    /**
+     * Sanitizes and validates the position setting.
+     * Ensures the input is one of the allowed position keys.
+     * Returns the valid input or a default value ('top-center') if invalid.
+     *
+     * @param string $input The position value from user input.
+     * @return string The sanitized and validated position string.
+     */
     public static function sanitize_position_setting($input) {
+        // $input is expected to be unslashed at this point.
+        // Validates against a predefined list of allowed values (keys of get_position_choices).
+        // This acts as both sanitization (by restricting to known safe values) and validation.
         return in_array($input, array_keys(self::get_position_choices()), true) ? $input : 'top-center';
     }
 
@@ -93,33 +95,33 @@ class A_FleK90_Tool_Floating_Field {
             __( 'FleK90 Tools', 'a-flek90-tool-floating-field' ), // Page title
             __( 'FleK90', 'a-flek90-tool-floating-field' ),       // Menu title
             'manage_options',                                 // Capability
-            'flek90_main_menu_slug',                          // Menu slug (this will be the parent slug)
-            [$this, 'flek90_main_menu_page_html_callback'],   // Callback function for the top-level page content
+            'aftff_main_menu_slug',                          // Menu slug (this will be the parent slug)
+            [$this, 'aftff_main_menu_page_html_callback'],   // Callback function for the top-level page content
             'dashicons-admin-generic',                        // Icon
             75                                                // Position
         );
 
         // Add the "Floating Field Settings" page as a submenu
         $this->settings_page_hook_suffix = add_submenu_page(
-            'flek90_main_menu_slug',                          // Parent slug
+            'aftff_main_menu_slug',                          // Parent slug
             __( 'Floating Field Settings', 'a-flek90-tool-floating-field' ), // Page title for menu
             __( 'Floating Field', 'a-flek90-tool-floating-field' ),          // Menu title for submenu item
             'manage_options',                                 // Capability
-            'flek90_floating_field_settings_slug',            // Menu slug for this submenu page (and its URL)
+            'aftff_floating_field_settings_slug',            // Menu slug for this submenu page (and its URL)
             [$this, 'render_admin_page']                      // Callback function for the page (now tabbed)
         );
         // Removed the separate "About" submenu page registration
     }
 
     // Placeholder callback for the main menu page
-    public function flek90_main_menu_page_html_callback() {
+    public function aftff_main_menu_page_html_callback() {
         if (!current_user_can('manage_options')) {
             wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'a-flek90-tool-floating-field'));
         }
         // Structure changed for precise theme scoping
         echo '<div class="wrap"><h1>' . esc_html__( 'FleK90 Tools Dashboard', 'a-flek90-tool-floating-field' ) . '</h1>';
-        echo '<div class="flek90-admin-page">'; // Open themed div
-        echo '<p>' . esc_html__( 'Welcome to the FleK90 Tools main dashboard. Please select a tool from the submenu.', 'a-flek90-tool-floating-field' ) . '</p>';
+        echo '<div class="aftff-admin-page">'; // Open themed div
+        echo '<p>' . esc_html__( 'Welcome to the AFTFF Tools main dashboard. Please select a tool from the submenu.', 'a-flek90-tool-floating-field' ) . '</p>';
         echo '</div>'; // Close .flek90-admin-page
         echo '</div>'; // Close .wrap
     }
@@ -135,29 +137,36 @@ class A_FleK90_Tool_Floating_Field {
 
 
         // Settings saving logic - only if on settings tab and form submitted
-        if ($active_tab === 'settings' && isset($_POST['flek90_save_settings']) && check_admin_referer('flek90_save_settings_action', 'flek90_save_settings_nonce')) {
-            update_option('flek90_enable_on_desktop_v5', isset($_POST['flek90_enable_on_desktop_v5']) ? '1' : '0');
-            update_option('flek90_enable_on_mobile_v5', isset($_POST['flek90_enable_on_mobile_v5']) ? '1' : '0');
-            if (isset($_POST['flek90_desktop_position_v5'])) { update_option('flek90_desktop_position_v5', self::sanitize_position_setting(wp_unslash($_POST['flek90_desktop_position_v5']))); }
-            if (isset($_POST['flek90_mobile_position_v5'])) { update_option('flek90_mobile_position_v5', self::sanitize_position_setting(wp_unslash($_POST['flek90_mobile_position_v5']))); }
-            if (isset($_POST['flek90_background_color_v5'])) { update_option('flek90_background_color_v5', sanitize_hex_color(wp_unslash($_POST['flek90_background_color_v5'])));}
-            if (isset($_POST['flek90_font_size_v5'])) { update_option('flek90_font_size_v5', absint(wp_unslash($_POST['flek90_font_size_v5'])));}
-            if (isset($_POST['flek90_field_width_v5'])) { update_option('flek90_field_width_v5', absint(wp_unslash($_POST['flek90_field_width_v5'])));}
-            if (isset($_POST['flek90_field_width_unit_v5'])) {
+        if ($active_tab === 'settings' && isset($_POST['aftff_save_settings']) && check_admin_referer('aftff_save_settings_action', 'aftff_save_settings_nonce')) {
+            update_option('aftff_enable_on_desktop_v5', isset($_POST['aftff_enable_on_desktop_v5']) ? '1' : '0');
+            update_option('aftff_enable_on_mobile_v5', isset($_POST['aftff_enable_on_mobile_v5']) ? '1' : '0');
+            if (isset($_POST['aftff_desktop_position_v5'])) { update_option('aftff_desktop_position_v5', self::sanitize_position_setting(wp_unslash($_POST['aftff_desktop_position_v5']))); }
+            if (isset($_POST['aftff_mobile_position_v5'])) { update_option('aftff_mobile_position_v5', self::sanitize_position_setting(wp_unslash($_POST['aftff_mobile_position_v5']))); }
+            if (isset($_POST['aftff_background_color_v5'])) { update_option('aftff_background_color_v5', sanitize_hex_color(wp_unslash($_POST['aftff_background_color_v5'])));}
+            if (isset($_POST['aftff_font_size_v5'])) { update_option('aftff_font_size_v5', absint(wp_unslash($_POST['aftff_font_size_v5'])));}
+            if (isset($_POST['aftff_field_width_v5'])) { update_option('aftff_field_width_v5', absint(wp_unslash($_POST['aftff_field_width_v5'])));}
+            if (isset($_POST['aftff_field_width_unit_v5'])) {
                 $allowed_units = ['px', '%', 'rem', 'em', 'vw'];
-                $submitted_unit = sanitize_text_field(wp_unslash($_POST['flek90_field_width_unit_v5']));
+                $submitted_unit = sanitize_text_field(wp_unslash($_POST['aftff_field_width_unit_v5']));
                 if (in_array($submitted_unit, $allowed_units, true)) {
-                    update_option('flek90_field_width_unit_v5', $submitted_unit);
+                    update_option('aftff_field_width_unit_v5', $submitted_unit);
                 } else {
-                    update_option('flek90_field_width_unit_v5', 'px'); // Default to px if invalid
+                    update_option('aftff_field_width_unit_v5', 'px'); // Default to px if invalid
                 }
             }
-            if (isset($_POST['flek90_content_desktop_v5'])) { update_option('flek90_content_desktop_v5', wp_kses_post(wp_unslash($_POST['flek90_content_desktop_v5']))); }
-            if (isset($_POST['flek90_content_mobile_v5'])) { update_option('flek90_content_mobile_v5', wp_kses_post(wp_unslash($_POST['flek90_content_mobile_v5']))); }
-            if (isset($_POST['flek90_custom_css_v5'])) { update_option('flek90_custom_css_v5', wp_strip_all_tags(wp_unslash($_POST['flek90_custom_css_v5']))); }
+            if (isset($_POST['aftff_content_desktop_v5'])) { update_option('aftff_content_desktop_v5', wp_kses_post(wp_unslash($_POST['aftff_content_desktop_v5']))); }
+            if (isset($_POST['aftff_content_mobile_v5'])) { update_option('aftff_content_mobile_v5', wp_kses_post(wp_unslash($_POST['aftff_content_mobile_v5']))); }
+            // Correctly save separate custom CSS fields
+            if (isset($_POST['aftff_custom_css_desktop_v5'])) { update_option('aftff_custom_css_desktop_v5', wp_strip_all_tags(wp_unslash($_POST['aftff_custom_css_desktop_v5']))); }
+            if (isset($_POST['aftff_custom_css_mobile_v5'])) { update_option('aftff_custom_css_mobile_v5', wp_strip_all_tags(wp_unslash($_POST['aftff_custom_css_mobile_v5']))); }
+            if (isset($_POST['aftff_prioritize_custom_css_v5'])) { update_option('aftff_prioritize_custom_css_v5', '1'); } else { update_option('aftff_prioritize_custom_css_v5', '0'); }
 
-            // Old option deletion logic
-            if (get_option('flek90_ff_customizer_settings') !== false) {
+
+            // Old option deletion logic - these should also be prefixed if they were specific to this plugin's old versions
+            // For now, keeping them as "flek90" as they refer to *old* options.
+            // If these were *never* prefixed uniquely, that was an issue too.
+            // Assuming they were `flek90_` prefixed.
+            if (get_option('flek90_ff_customizer_settings') !== false) { // Example: if this was an old option name
                 delete_option('flek90_ff_customizer_settings');
             }
             $old_options = ['flek90_enable_field', 'flek90_mobile_only', 'flek90_field_content', 'flek90_background_color', 'flek90_font_size', 'flek90_custom_css'];
@@ -167,32 +176,32 @@ class A_FleK90_Tool_Floating_Field {
             echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Settings saved successfully!', 'a-flek90-tool-floating-field') . '</p></div>';
         }
         ?>
-        <div class="wrap"> <!-- Removed flek90-admin-page class from here -->
+        <div class="wrap"> <!-- Removed aftff-admin-page class from here -->
             <h1><?php esc_html_e('A FleK90 Tool Floating Field', 'a-flek90-tool-floating-field'); ?> - v<?php echo esc_html($plugin_version_display); ?></h1>
 
             <h2 class="nav-tab-wrapper">
-                <a href="?page=flek90_floating_field_settings_slug&tab=settings" class="nav-tab <?php echo $active_tab === 'settings' ? 'nav-tab-active' : ''; ?>">
+                <a href="?page=aftff_floating_field_settings_slug&tab=settings" class="nav-tab <?php echo $active_tab === 'settings' ? 'nav-tab-active' : ''; ?>">
                     <?php esc_html_e('Settings', 'a-flek90-tool-floating-field'); ?>
                 </a>
-                <a href="?page=flek90_floating_field_settings_slug&tab=about" class="nav-tab <?php echo $active_tab === 'about' ? 'nav-tab-active' : ''; ?>">
+                <a href="?page=aftff_floating_field_settings_slug&tab=about" class="nav-tab <?php echo $active_tab === 'about' ? 'nav-tab-active' : ''; ?>">
                     <?php esc_html_e('About', 'a-flek90-tool-floating-field'); ?>
                 </a>
             </h2>
 
-            <div class="flek90-admin-page"> <!-- Added flek90-admin-page wrapper here -->
+            <div class="aftff-admin-page"> <!-- Added aftff-admin-page wrapper here -->
                 <div class="tab-content" style="padding-top: 20px;">
                     <?php if ($active_tab === 'settings') : ?>
                         <?php
                         // Retrieve settings for the form
-                    $enable_on_desktop_v5 = get_option('flek90_enable_on_desktop_v5', '1');
-                    $enable_on_mobile_v5 = get_option('flek90_enable_on_mobile_v5', '1');
-                    $desktop_position_v5 = get_option('flek90_desktop_position_v5', 'top-center');
-                    $mobile_position_v5 = get_option('flek90_mobile_position_v5', 'top-center');
-                    $background_color_v5 = get_option('flek90_background_color_v5', '#0073aa');
-                    $font_size_v5 = get_option('flek90_font_size_v5', '24');
-                    $field_width_v5 = get_option('flek90_field_width_v5', '280'); // Default to 280px
-                    $field_width_unit_v5 = get_option('flek90_field_width_unit_v5', 'px'); // Default to 'px'
-                    $custom_css_v5 = get_option('flek90_custom_css_v5', '');
+                    $enable_on_desktop_v5 = get_option('aftff_enable_on_desktop_v5', '1');
+                    $enable_on_mobile_v5 = get_option('aftff_enable_on_mobile_v5', '1');
+                    $desktop_position_v5 = get_option('aftff_desktop_position_v5', 'top-center');
+                    $mobile_position_v5 = get_option('aftff_mobile_position_v5', 'top-center');
+                    $background_color_v5 = get_option('aftff_background_color_v5', '#0073aa');
+                    $font_size_v5 = get_option('aftff_font_size_v5', '24');
+                    $field_width_v5 = get_option('aftff_field_width_v5', '280'); // Default to 280px
+                    $field_width_unit_v5 = get_option('aftff_field_width_unit_v5', 'px'); // Default to 'px'
+                    // $custom_css_v5 = get_option('aftff_custom_css_v5', ''); // This option is no longer used directly for display
                     $pos_choices = self::get_position_choices();
 
                     // Define default content examples
@@ -210,29 +219,29 @@ class A_FleK90_Tool_Floating_Field {
                                                       '  <p>Shortcode: [my_contact_form_shortcode]</p>' . "\n" .
                                                       '</div>';
                     ?>
-                    <form method="post" action="?page=flek90_floating_field_settings_slug&tab=settings">
-                        <?php wp_nonce_field('flek90_save_settings_action', 'flek90_save_settings_nonce'); ?>
+                    <form method="post" action="?page=aftff_floating_field_settings_slug&tab=settings">
+                        <?php wp_nonce_field('aftff_save_settings_action', 'aftff_save_settings_nonce'); ?>
                         <table class="form-table">
                             <tr valign="top"><td colspan="2"><h3><?php esc_html_e('Display Control', 'a-flek90-tool-floating-field'); ?></h3></td></tr>
-                            <tr><th scope="row"><label for="flek90_enable_on_desktop_v5"><?php esc_html_e('Enable on Desktop', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="checkbox" id="flek90_enable_on_desktop_v5" name="flek90_enable_on_desktop_v5" value="1" <?php checked($enable_on_desktop_v5, '1'); ?>><p class="description"><?php esc_html_e('Show the floating field on desktop devices.', 'a-flek90-tool-floating-field'); ?></p></td></tr>
-                            <tr><th scope="row"><label for="flek90_enable_on_mobile_v5"><?php esc_html_e('Enable on Mobile', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="checkbox" id="flek90_enable_on_mobile_v5" name="flek90_enable_on_mobile_v5" value="1" <?php checked($enable_on_mobile_v5, '1'); ?>><p class="description"><?php esc_html_e('Show the floating field on mobile devices.', 'a-flek90-tool-floating-field'); ?></p></td></tr>
+                            <tr><th scope="row"><label for="aftff_enable_on_desktop_v5"><?php esc_html_e('Enable on Desktop', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="checkbox" id="aftff_enable_on_desktop_v5" name="aftff_enable_on_desktop_v5" value="1" <?php checked($enable_on_desktop_v5, '1'); ?>><p class="description"><?php esc_html_e('Show the floating field on desktop devices.', 'a-flek90-tool-floating-field'); ?></p></td></tr>
+                            <tr><th scope="row"><label for="aftff_enable_on_mobile_v5"><?php esc_html_e('Enable on Mobile', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="checkbox" id="aftff_enable_on_mobile_v5" name="aftff_enable_on_mobile_v5" value="1" <?php checked($enable_on_mobile_v5, '1'); ?>><p class="description"><?php esc_html_e('Show the floating field on mobile devices.', 'a-flek90-tool-floating-field'); ?></p></td></tr>
 
                             <tr valign="top"><td colspan="2"><hr><h3><?php esc_html_e('Content Settings', 'a-flek90-tool-floating-field'); ?></h3></td></tr>
                             <tr valign="top">
                                 <th scope="row">
-                                    <label for="flek90_content_desktop_v5"><?php esc_html_e('Desktop Content', 'a-flek90-tool-floating-field'); ?></label>
+                                    <label for="aftff_content_desktop_v5"><?php esc_html_e('Desktop Content', 'a-flek90-tool-floating-field'); ?></label>
                                 </th>
                                 <td>
-                                    <textarea id="flek90_content_desktop_v5" name="flek90_content_desktop_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('flek90_content_desktop_v5', $default_desktop_content_example)); ?></textarea>
+                                    <textarea id="aftff_content_desktop_v5" name="aftff_content_desktop_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('aftff_content_desktop_v5', $default_desktop_content_example)); ?></textarea>
                                     <p class="description"><?php esc_html_e('Enter your HTML content. Use %page_title% to display the current page/post title. For dynamic PHP-like functionality, use or create WordPress shortcodes (e.g., [your_shortcode]). The example shows basic HTML, the page title tag, and a placeholder for a shortcode. Note: You would need to define shortcodes like [current_year_example_shortcode] or [my_contact_form_shortcode] in your theme or another plugin for them to work.', 'a-flek90-tool-floating-field'); ?></p>
                                 </td>
                             </tr>
                             <tr valign="top">
                                 <th scope="row">
-                                    <label for="flek90_content_mobile_v5"><?php esc_html_e('Mobile Content', 'a-flek90-tool-floating-field'); ?></label>
+                                    <label for="aftff_content_mobile_v5"><?php esc_html_e('Mobile Content', 'a-flek90-tool-floating-field'); ?></label>
                                 </th>
                                 <td>
-                                    <textarea id="flek90_content_mobile_v5" name="flek90_content_mobile_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('flek90_content_mobile_v5', $default_mobile_content_example)); ?></textarea>
+                                    <textarea id="aftff_content_mobile_v5" name="aftff_content_mobile_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('aftff_content_mobile_v5', $default_mobile_content_example)); ?></textarea>
                                     <p class="description"><?php esc_html_e('Enter your HTML content. Use %page_title% to display the current page/post title. For dynamic PHP-like functionality, use or create WordPress shortcodes (e.g., [your_shortcode]). The example shows basic HTML, the page title tag, and a placeholder for a shortcode. Note: You would need to define shortcodes like [my_contact_form_shortcode] in your theme or another plugin for them to work.', 'a-flek90-tool-floating-field'); ?></p>
                                 </td>
                             </tr>
@@ -240,17 +249,17 @@ class A_FleK90_Tool_Floating_Field {
                             <tr valign="top"><td colspan="2" style="padding-top: 0;"></td></tr>
 
                             <tr valign="top"><td colspan="2"><hr><h3><?php esc_html_e('Position Settings (Simplified)', 'a-flek90-tool-floating-field'); ?></h3><p class="description"><?php esc_html_e('Select a general position. Offsets are no longer configured on this page.', 'a-flek90-tool-floating-field'); ?></p></td></tr>
-                            <tr><th scope="row"><label for="flek90_desktop_position_v5"><?php esc_html_e('Desktop Position', 'a-flek90-tool-floating-field'); ?></label></th><td><select id="flek90_desktop_position_v5" name="flek90_desktop_position_v5"><?php foreach ($pos_choices as $value => $label) : ?><option value="<?php echo esc_attr($value); ?>" <?php selected($desktop_position_v5, $value); ?>><?php echo esc_html($label); ?></option><?php endforeach; ?></select></td></tr>
-                            <tr><th scope="row"><label for="flek90_mobile_position_v5"><?php esc_html_e('Mobile Position', 'a-flek90-tool-floating-field'); ?></label></th><td><select id="flek90_mobile_position_v5" name="flek90_mobile_position_v5"><?php foreach ($pos_choices as $value => $label) : ?><option value="<?php echo esc_attr($value); ?>" <?php selected($mobile_position_v5, $value); ?>><?php echo esc_html($label); ?></option><?php endforeach; ?></select></td></tr>
+                            <tr><th scope="row"><label for="aftff_desktop_position_v5"><?php esc_html_e('Desktop Position', 'a-flek90-tool-floating-field'); ?></label></th><td><select id="aftff_desktop_position_v5" name="aftff_desktop_position_v5"><?php foreach ($pos_choices as $value => $label) : ?><option value="<?php echo esc_attr($value); ?>" <?php selected($desktop_position_v5, $value); ?>><?php echo esc_html($label); ?></option><?php endforeach; ?></select></td></tr>
+                            <tr><th scope="row"><label for="aftff_mobile_position_v5"><?php esc_html_e('Mobile Position', 'a-flek90-tool-floating-field'); ?></label></th><td><select id="aftff_mobile_position_v5" name="aftff_mobile_position_v5"><?php foreach ($pos_choices as $value => $label) : ?><option value="<?php echo esc_attr($value); ?>" <?php selected($mobile_position_v5, $value); ?>><?php echo esc_html($label); ?></option><?php endforeach; ?></select></td></tr>
 
                             <tr valign="top"><td colspan="2"><hr><h3><?php esc_html_e('Appearance Settings', 'a-flek90-tool-floating-field'); ?></h3></td></tr>
-                            <tr><th scope="row"><label for="flek90_background_color_v5"><?php esc_html_e('Background Color', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="text" id="flek90_background_color_v5" name="flek90_background_color_v5" value="<?php echo esc_attr($background_color_v5); ?>" class="flek90-color-picker-field"><p class="description"><?php esc_html_e('Select background color (default: blue).', 'a-flek90-tool-floating-field'); ?></p></td></tr>
-                            <tr><th scope="row"><label for="flek90_font_size_v5"><?php esc_html_e('Font Size (px)', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="number" id="flek90_font_size_v5" name="flek90_font_size_v5" value="<?php echo esc_attr($font_size_v5); ?>" min="12" max="48" step="1"><p class="description"><?php esc_html_e('Set font size (12–48px, default: 24px).', 'a-flek90-tool-floating-field'); ?></p></td></tr>
+                            <tr><th scope="row"><label for="aftff_background_color_v5"><?php esc_html_e('Background Color', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="text" id="aftff_background_color_v5" name="aftff_background_color_v5" value="<?php echo esc_attr($background_color_v5); ?>" class="aftff-color-picker-field"><p class="description"><?php esc_html_e('Select background color (default: blue).', 'a-flek90-tool-floating-field'); ?></p></td></tr>
+                            <tr><th scope="row"><label for="aftff_font_size_v5"><?php esc_html_e('Font Size (px)', 'a-flek90-tool-floating-field'); ?></label></th><td><input type="number" id="aftff_font_size_v5" name="aftff_font_size_v5" value="<?php echo esc_attr($font_size_v5); ?>" min="12" max="48" step="1"><p class="description"><?php esc_html_e('Set font size (12–48px, default: 24px).', 'a-flek90-tool-floating-field'); ?></p></td></tr>
                             <tr>
-                                <th scope="row"><label for="flek90_field_width_v5"><?php esc_html_e('Field Width', 'a-flek90-tool-floating-field'); ?></label></th>
+                                <th scope="row"><label for="aftff_field_width_v5"><?php esc_html_e('Field Width', 'a-flek90-tool-floating-field'); ?></label></th>
                                 <td style="display: flex; align-items: center; gap: 10px;">
-                                    <input type="number" id="flek90_field_width_v5" name="flek90_field_width_v5" value="<?php echo esc_attr($field_width_v5); ?>" min="10" max="1000" step="1" style="width: 80px;">
-                                    <select id="flek90_field_width_unit_v5" name="flek90_field_width_unit_v5" style="flex-shrink: 0;">
+                                    <input type="number" id="aftff_field_width_v5" name="aftff_field_width_v5" value="<?php echo esc_attr($field_width_v5); ?>" min="10" max="1000" step="1" style="width: 80px;">
+                                    <select id="aftff_field_width_unit_v5" name="aftff_field_width_unit_v5" style="flex-shrink: 0;">
                                         <?php
                                         $units = ['px', '%', 'rem', 'em', 'vw'];
                                         foreach ($units as $unit) {
@@ -264,29 +273,29 @@ class A_FleK90_Tool_Floating_Field {
 
                             <tr valign="top"><td colspan="2"><hr><h3><?php esc_html_e('Custom CSS Settings', 'a-flek90-tool-floating-field'); ?></h3></td></tr>
                             <tr valign="top">
-                                <th scope="row"><label for="flek90_custom_css_desktop_v5"><?php esc_html_e('Custom CSS for Desktop', 'a-flek90-tool-floating-field'); ?></label></th>
+                                <th scope="row"><label for="aftff_custom_css_desktop_v5"><?php esc_html_e('Custom CSS for Desktop', 'a-flek90-tool-floating-field'); ?></label></th>
                                 <td>
-                                    <textarea id="flek90_custom_css_desktop_v5" name="flek90_custom_css_desktop_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('flek90_custom_css_desktop_v5', '')); ?></textarea>
+                                    <textarea id="aftff_custom_css_desktop_v5" name="aftff_custom_css_desktop_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('aftff_custom_css_desktop_v5', '')); ?></textarea>
                                     <p class="description"><?php esc_html_e('Add custom CSS rules to be applied for desktop views. Example: #flek90-floating-container { border: 2px solid blue !important; }', 'a-flek90-tool-floating-field'); ?></p>
                                 </td>
                             </tr>
                             <tr valign="top">
-                                <th scope="row"><label for="flek90_custom_css_mobile_v5"><?php esc_html_e('Custom CSS for Mobile', 'a-flek90-tool-floating-field'); ?></label></th>
+                                <th scope="row"><label for="aftff_custom_css_mobile_v5"><?php esc_html_e('Custom CSS for Mobile', 'a-flek90-tool-floating-field'); ?></label></th>
                                 <td>
-                                    <textarea id="flek90_custom_css_mobile_v5" name="flek90_custom_css_mobile_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('flek90_custom_css_mobile_v5', '')); ?></textarea>
+                                    <textarea id="aftff_custom_css_mobile_v5" name="aftff_custom_css_mobile_v5" rows="10" cols="50" class="large-text code"><?php echo esc_textarea(get_option('aftff_custom_css_mobile_v5', '')); ?></textarea>
                                     <p class="description"><?php esc_html_e('Add custom CSS rules to be applied for mobile views (typically within a max-width: 768px media query). Example: #flek90-floating-container { font-size: 12px !important; }', 'a-flek90-tool-floating-field'); ?></p>
                                 </td>
                             </tr>
                             <tr valign="top">
                                 <th scope="row"><?php esc_html_e('CSS Override', 'a-flek90-tool-floating-field'); ?></th>
                                 <td>
-                                    <input type="checkbox" id="flek90_prioritize_custom_css_v5" name="flek90_prioritize_custom_css_v5" value="1" <?php checked(get_option('flek90_prioritize_custom_css_v5', '0'), '1'); ?> />
-                                    <label for="flek90_prioritize_custom_css_v5"><?php esc_html_e('Prioritize Custom CSS for Styles', 'a-flek90-tool-floating-field'); ?></label>
+                                    <input type="checkbox" id="aftff_prioritize_custom_css_v5" name="aftff_prioritize_custom_css_v5" value="1" <?php checked(get_option('aftff_prioritize_custom_css_v5', '0'), '1'); ?> />
+                                    <label for="aftff_prioritize_custom_css_v5"><?php esc_html_e('Prioritize Custom CSS for Styles', 'a-flek90-tool-floating-field'); ?></label>
                                     <p class="description"><?php esc_html_e('If checked, your Custom CSS for Desktop/Mobile will take full control over appearance (background, font size, width). The plugin\'s specific settings for these will be ignored, allowing your CSS to prevail.', 'a-flek90-tool-floating-field'); ?></p>
                                 </td>
                             </tr>
                         </table>
-                        <p class="submit"><input type="submit" name="flek90_save_settings" class="button button-primary" value="<?php esc_attr_e('Save Settings', 'a-flek90-tool-floating-field'); ?>"></p>
+                        <p class="submit"><input type="submit" name="aftff_save_settings" class="button button-primary" value="<?php esc_attr_e('Save Settings', 'a-flek90-tool-floating-field'); ?>"></p>
                     </form>
 
                 <?php elseif ($active_tab === 'about') : ?>
@@ -311,18 +320,18 @@ class A_FleK90_Tool_Floating_Field {
 
                     <h3><?php esc_html_e('Screenshots', 'a-flek90-tool-floating-field'); ?></h3>
                     <p><em><?php esc_html_e('Note: Screenshot images (floating_field_example.jpg, floating_field_example2.jpg, Floating_field_admin_menu.jpg) need to be placed in the plugin\'s assets/images/ directory.', 'a-flek90-tool-floating-field'); ?></em></p>
-                    <div class="flek90-screenshots">
-                        <div class="flek90-screenshot">
+                    <div class="aftff-screenshots">
+                        <div class="aftff-screenshot">
                             <img src="<?php echo esc_url($assets_url . 'images/floating_field_example.jpg'); ?>" alt="<?php esc_attr_e('Floating Field Example 1', 'a-flek90-tool-floating-field'); ?>">
                             <p><em><?php esc_html_e('Example 1: Floating field in action.', 'a-flek90-tool-floating-field'); ?></em></p>
                         </div>
-                        <div class="flek90-screenshot">
+                        <div class="aftff-screenshot">
                             <img src="<?php echo esc_url($assets_url . 'images/floating_field_example2.jpg'); ?>" alt="<?php esc_attr_e('Floating Field Example 2', 'a-flek90-tool-floating-field'); ?>">
                             <p><em><?php esc_html_e('Example 2: Another view of the floating field.', 'a-flek90-tool-floating-field'); ?></em></p>
                         </div>
-                        <div class="flek90-screenshot">
+                        <div class="aftff-screenshot">
                             <img src="<?php echo esc_url($assets_url . 'images/Floating_field_admin_menu.jpg'); ?>" alt="<?php esc_attr_e('Screenshot 4: Admin Menu Structure', 'a-flek90-tool-floating-field'); ?>">
-                            <p><em><?php esc_html_e('The FleK90 Tools admin menu and Floating Field submenu.', 'a-flek90-tool-floating-field'); ?></em></p>
+                            <p><em><?php esc_html_e('The AFTFF Tools admin menu and Floating Field submenu.', 'a-flek90-tool-floating-field'); ?></em></p>
                         </div>
                     </div>
 
@@ -369,13 +378,13 @@ class A_FleK90_Tool_Floating_Field {
     }
 
     public function enqueue_scripts() {
-        $prioritize_custom_css = get_option('flek90_prioritize_custom_css_v5', '0') === '1';
+        $prioritize_custom_css = get_option('aftff_prioritize_custom_css_v5', '0') === '1';
 
-        wp_register_style('flek90-floating-field-inline', false, [], $this->plugin_version);
-        wp_enqueue_style('flek90-floating-field-inline');
+        wp_register_style('aftff-floating-field-inline', false, [], $this->plugin_version);
+        wp_enqueue_style('aftff-floating-field-inline');
 
-        $desktop_position_v5 = get_option('flek90_desktop_position_v5', 'top-center');
-        $mobile_position_v5 = get_option('flek90_mobile_position_v5', 'top-center');
+        $desktop_position_v5 = get_option('aftff_desktop_position_v5', 'top-center');
+        $mobile_position_v5 = get_option('aftff_mobile_position_v5', 'top-center');
 
         $desktop_pos_css = $this->generate_position_css_v5($desktop_position_v5);
         $mobile_pos_css = $this->generate_position_css_v5($mobile_position_v5);
@@ -384,11 +393,11 @@ class A_FleK90_Tool_Floating_Field {
         $mobile_dynamic_styles = "";
 
         if (!$prioritize_custom_css) {
-            $background_color_option = get_option('flek90_background_color_v5', '#0073aa');
+            $background_color_option = get_option('aftff_background_color_v5', '#0073aa');
             $css_background_color = !empty($background_color_option) ? esc_attr($background_color_option) : 'transparent';
-            $font_size_v5 = get_option('flek90_font_size_v5', '24');
-            $field_width_v5 = get_option('flek90_field_width_v5', '280');
-            $field_width_unit_v5 = get_option('flek90_field_width_unit_v5', 'px');
+            $font_size_v5 = get_option('aftff_font_size_v5', '24');
+            $field_width_v5 = get_option('aftff_field_width_v5', '280');
+            $field_width_unit_v5 = get_option('aftff_field_width_unit_v5', 'px');
             $allowed_units = ['px', '%', 'rem', 'em', 'vw'];
             if (!in_array($field_width_unit_v5, $allowed_units, true)) {
                 $field_width_unit_v5 = 'px';
@@ -414,28 +423,28 @@ class A_FleK90_Tool_Floating_Field {
         }
 
         $css = "
-    #flek90-floating-container {
+    #aftff-floating-container {
         position: fixed !important; {$desktop_pos_css} z-index: 9999; {$dynamic_styles} color: #fff; padding: 1px 1px; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); text-align: center; box-sizing: border-box; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     }
-    #flek90-floating-container * { color: inherit; line-height: 1.5; }
-    #flek90-floating-container a { color: #fff; text-decoration: underline; }
-    #flek90-floating-container a:hover { color: #ddd; }
-    #flek90-floating-container form#searchform { display: flex; align-items: center; gap: 10px; flex-direction: row; }
-    #flek90-floating-container input.search-input { background: #fff; color: #333; border: 1px solid #ccc; padding: 1px 1px; font-size: 14px; width: 200px; border-radius: 4px; box-shadow: inset 0 1px 2px rgba(0,0,0,0.1); transition: border-color 0.2s ease-in-out; }
-    #flek90-floating-container input.search-input:focus { border-color: #007cba; outline: none; box-shadow: 0 0 0 1px #007cba; }
-    #flek90-floating-container button.search-submit { background: #fff; color: #333; border: 1px solid #ccc; padding: 0; width: 32px; height: 32px; border-radius: 4px; cursor: pointer; transition: background-color 0.2s ease-in-out; display: flex; align-items: center; justify-content: center; }
-    #flek90-floating-container button.search-submit:hover { background: #f5f5f5; }
-    #flek90-floating-container button.search-submit svg { width: 16px; height: 16px; stroke: #000; stroke-width: 3; }
+    #aftff-floating-container * { color: inherit; line-height: 1.5; }
+    #aftff-floating-container a { color: #fff; text-decoration: underline; }
+    #aftff-floating-container a:hover { color: #ddd; }
+    #aftff-floating-container form#searchform { display: flex; align-items: center; gap: 10px; flex-direction: row; }
+    #aftff-floating-container input.search-input { background: #fff; color: #333; border: 1px solid #ccc; padding: 1px 1px; font-size: 14px; width: 200px; border-radius: 4px; box-shadow: inset 0 1px 2px rgba(0,0,0,0.1); transition: border-color 0.2s ease-in-out; }
+    #aftff-floating-container input.search-input:focus { border-color: #007cba; outline: none; box-shadow: 0 0 0 1px #007cba; }
+    #aftff-floating-container button.search-submit { background: #fff; color: #333; border: 1px solid #ccc; padding: 0; width: 32px; height: 32px; border-radius: 4px; cursor: pointer; transition: background-color 0.2s ease-in-out; display: flex; align-items: center; justify-content: center; }
+    #aftff-floating-container button.search-submit:hover { background: #f5f5f5; }
+    #aftff-floating-container button.search-submit svg { width: 16px; height: 16px; stroke: #000; stroke-width: 3; }
     @media (max-width: 768px) {
-        #flek90-floating-container { {$mobile_pos_css} {$mobile_dynamic_styles} padding: 2px 2px; width: auto; }
-        #flek90-floating-container form#searchform { gap: 5px; }
-        #flek90-floating-container input.search-input { width: 150px; font-size: 13px; padding: 6px 10px; }
-        #flek90-floating-container button.search-submit { width: 28px; height: 28px; }
-        #flek90-floating-container button.search-submit svg { width: 14px; height: 14px; }
+        #aftff-floating-container { {$mobile_pos_css} {$mobile_dynamic_styles} padding: 2px 2px; width: auto; }
+        #aftff-floating-container form#searchform { gap: 5px; }
+        #aftff-floating-container input.search-input { width: 150px; font-size: 13px; padding: 6px 10px; }
+        #aftff-floating-container button.search-submit { width: 28px; height: 28px; }
+        #aftff-floating-container button.search-submit svg { width: 14px; height: 14px; }
     }";
 
         // Add Desktop Custom CSS
-        $custom_css_desktop_v5 = get_option('flek90_custom_css_desktop_v5', '');
+        $custom_css_desktop_v5 = get_option('aftff_custom_css_desktop_v5', '');
         $trimmed_custom_css_desktop = trim($custom_css_desktop_v5);
         if (!empty($trimmed_custom_css_desktop)) {
             $css .= "
@@ -445,7 +454,7 @@ class A_FleK90_Tool_Floating_Field {
         }
 
         // Add Mobile Custom CSS (within the media query)
-        $custom_css_mobile_v5 = get_option('flek90_custom_css_mobile_v5', '');
+        $custom_css_mobile_v5 = get_option('aftff_custom_css_mobile_v5', '');
         $trimmed_custom_css_mobile = trim($custom_css_mobile_v5);
         if (!empty($trimmed_custom_css_mobile)) {
             // Check if the media query part is already in $css, if not, add it.
@@ -488,14 +497,14 @@ class A_FleK90_Tool_Floating_Field {
 }";
             }
         }
-        wp_add_inline_style('flek90-floating-field-inline', $css);
+        wp_add_inline_style('aftff-floating-field-inline', $css);
     }
 
 public function render_floating_field() {
 
     $is_mobile = wp_is_mobile();
-    $enabled_on_desktop = get_option('flek90_enable_on_desktop_v5', '1');
-    $enabled_on_mobile = get_option('flek90_enable_on_mobile_v5', '1');
+    $enabled_on_desktop = get_option('aftff_enable_on_desktop_v5', '1');
+    $enabled_on_mobile = get_option('aftff_enable_on_mobile_v5', '1');
 
     if (($is_mobile && $enabled_on_mobile !== '1') || (!$is_mobile && $enabled_on_desktop !== '1')) {
         return;
@@ -508,9 +517,9 @@ public function render_floating_field() {
     $content = '';
 
     if ($is_mobile) {
-        $content = get_option('flek90_content_mobile_v5', '');
+        $content = get_option('aftff_content_mobile_v5', '');
     } else {
-        $content = get_option('flek90_content_desktop_v5', '');
+        $content = get_option('aftff_content_desktop_v5', '');
     }
 
     // If device-specific content is empty, try to fall back to the other device's content.
@@ -520,10 +529,10 @@ public function render_floating_field() {
     if (empty(trim($content))) {
         if ($is_mobile) {
             // Mobile content was empty, try desktop
-            $content = get_option('flek90_content_desktop_v5', '');
+            $content = get_option('aftff_content_desktop_v5', '');
         } else {
             // Desktop content was empty, try mobile
-            $content = get_option('flek90_content_mobile_v5', '');
+            $content = get_option('aftff_content_mobile_v5', '');
         }
     }
 
@@ -554,8 +563,8 @@ public function render_floating_field() {
 
 
     ?>
-    <div id="flek90-floating-container">
-        <div id="flek90-field-content"><?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized by $this->sanitize_content ?></div>
+    <div id="aftff-floating-container">
+        <div id="aftff-field-content"><?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized by $this->sanitize_content ?></div>
     </div>
     <?php
 }
@@ -567,27 +576,27 @@ public function render_floating_field() {
     // Combined admin assets enqueuing
     public function enqueue_admin_assets($hook_suffix) {
 
-        $is_flek90_admin_page = false;
-        // Check for the main FleK90 Tools dashboard page or the unified Settings/About page.
-        if ($hook_suffix === 'toplevel_page_flek90_main_menu_slug' ||
+        $is_aftff_admin_page = false;
+        // Check for the main AFTFF Tools dashboard page or the unified Settings/About page.
+        if ($hook_suffix === 'toplevel_page_aftff_main_menu_slug' ||
             $hook_suffix === $this->settings_page_hook_suffix ) { // $this->details_page_hook_suffix is removed
-            $is_flek90_admin_page = true;
+            $is_aftff_admin_page = true;
         }
 
-        if ($is_flek90_admin_page) {
+        if ($is_aftff_admin_page) {
             wp_enqueue_style(
-                'flek90-admin-styles',
-                plugin_dir_url(__FILE__) . 'assets/css/flek90-admin-styles.css',
+                'aftff-admin-styles',
+                plugin_dir_url(__FILE__) . 'assets/css/aftff-admin-styles.css',
                 [],
                 $this->plugin_version
             );
 
             // Conditionally enqueue color picker scripts only on the settings page
-            if ($this->settings_page_hook_suffix == $hook_suffix) {
+            if ($this->settings_page_hook_suffix == $hook_suffix) { // hook_suffix is already correct from add_submenu_page
                 wp_enqueue_style('wp-color-picker'); // Already enqueued by WordPress if needed by other plugins, but good practice.
                 wp_enqueue_script(
-                    'flek90-color-picker-init',
-                    plugin_dir_url(__FILE__) . 'assets/js/flek90-color-picker-init.js',
+                    'aftff-color-picker-init',
+                    plugin_dir_url(__FILE__) . 'assets/js/aftff-color-picker-init.js',
                     ['wp-color-picker', 'jquery'],
                     $this->plugin_version,
                     true
@@ -598,7 +607,7 @@ public function render_floating_field() {
     }
 
     public function add_settings_link_to_plugin_list($links) {
-        $settings_slug = 'flek90_floating_field_settings_slug';
+        $settings_slug = 'aftff_floating_field_settings_slug';
         $settings_url = admin_url('admin.php?page=' . $settings_slug);
         $settings_link_html = '<a href="' . esc_url($settings_url) . '">' . __('Settings', 'a-flek90-tool-floating-field') . '</a>';
 
@@ -612,7 +621,7 @@ public function render_floating_field() {
     }
     // Removed render_plugin_details_page_html() as its content is now in render_admin_page() 'about' tab
 }
-try { new A_FleK90_Tool_Floating_Field(); } catch (Exception $e) {
+try { new AFTFF_Floating_Field_Plugin(); } catch (Exception $e) {
     // Note: $this->plugin_version is not available in this static context if class instantiation fails.
     // Consider logging a generic version or fetching it differently if needed here.
 }

--- a/assets/css/aftff-admin-styles.css
+++ b/assets/css/aftff-admin-styles.css
@@ -1,109 +1,109 @@
-/* FleK90 Admin Theme - Black and Gold */
+/* AFTFF Admin Theme - Black and Gold */
 :root {
-    --flek90-gold: #FFD700;
-    --flek90-dark-bg: #23282D;
-    --flek90-light-text: #E0E0E0;
-    --flek90-dark-text: #1A1A1A;
+    --aftff-gold: #FFD700;
+    --aftff-dark-bg: #23282D;
+    --aftff-light-text: #E0E0E0;
+    --aftff-dark-text: #1A1A1A;
 }
 
-/* FleK90 Menu Styling (Ensure correct admin menu body classes or IDs are used if available) */
+/* AFTFF Menu Styling (Ensure correct admin menu body classes or IDs are used if available) */
 /*
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-menu-name,
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-menu-image::before {
-    color: var(--flek90-light-text);
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug .wp-menu-name,
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug .wp-menu-image::before {
+    color: var(--aftff-light-text);
 }
 
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug:hover .wp-menu-name,
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug:hover .wp-menu-image::before {
-    color: var(--flek90-gold);
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug:hover .wp-menu-name,
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug:hover .wp-menu-image::before {
+    color: var(--aftff-gold);
 }
 */
 /* Current/Active Top Level Menu Item */
 /*
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug.wp-has-current-submenu > a.wp-has-current-submenu,
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug.current > a.current { /* For when top level itself is current */
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug.wp-has-current-submenu > a.wp-has-current-submenu,
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug.current > a.current { /* For when top level itself is current */
 /*
-    background-color: var(--flek90-gold);
-    color: var(--flek90-dark-text);
+    background-color: var(--aftff-gold);
+    color: var(--aftff-dark-text);
 }
 
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug.wp-has-current-submenu > a.wp-has-current-submenu .wp-menu-image::before,
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug.current > a.current .wp-menu-image::before {
-    color: var(--flek90-dark-text);
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug.wp-has-current-submenu > a.wp-has-current-submenu .wp-menu-image::before,
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug.current > a.current .wp-menu-image::before {
+    color: var(--aftff-dark-text);
 }
 */
 /* Submenu Items */
 /*
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-submenu a {
-    color: var(--flek90-light-text);
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug .wp-submenu a {
+    color: var(--aftff-light-text);
 }
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-submenu a:hover {
-    color: var(--flek90-gold);
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug .wp-submenu a:hover {
+    color: var(--aftff-gold);
 }
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-submenu li.current a,
-body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-submenu li.current a:hover {
-    color: var(--flek90-gold);
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug .wp-submenu li.current a,
+body.admin-color-fresh #adminmenu #toplevel_page_aftff_main_menu_slug .wp-submenu li.current a:hover {
+    color: var(--aftff-gold);
     font-weight: bold;
 }
 */
 
-/* Apply dark background to FleK90 Admin Pages */
-.flek90-admin-page {
-    background-color: var(--flek90-dark-bg);
-    color: var(--flek90-light-text);
+/* Apply dark background to AFTFF Admin Pages */
+.aftff-admin-page {
+    background-color: var(--aftff-dark-bg);
+    color: var(--aftff-light-text);
     padding: 10px 20px; /* Add some padding */
     border-radius: 4px; /* Optional: rounded corners for the content area */
 }
-.flek90-admin-page h1,
-.flek90-admin-page h2,
-.flek90-admin-page h3,
-.flek90-admin-page h4,
-.flek90-admin-page h5,
-.flek90-admin-page h6 {
-    color: var(--flek90-gold);
+.aftff-admin-page h1,
+.aftff-admin-page h2,
+.aftff-admin-page h3,
+.aftff-admin-page h4,
+.aftff-admin-page h5,
+.aftff-admin-page h6 {
+    color: var(--aftff-gold);
 }
-.flek90-admin-page p,
-.flek90-admin-page .description,
-.flek90-admin-page label {
-    color: var(--flek90-light-text);
+.aftff-admin-page p,
+.aftff-admin-page .description,
+.aftff-admin-page label {
+    color: var(--aftff-light-text);
 }
-.flek90-admin-page .form-table th {
-    color: var(--flek90-light-text);
+.aftff-admin-page .form-table th {
+    color: var(--aftff-light-text);
 }
-.flek90-admin-page .button-primary {
-    background: var(--flek90-gold) !important;
-    border-color: var(--flek90-gold) !important;
-    color: var(--flek90-dark-text) !important;
+.aftff-admin-page .button-primary {
+    background: var(--aftff-gold) !important;
+    border-color: var(--aftff-gold) !important;
+    color: var(--aftff-dark-text) !important;
     box-shadow: none !important;
     text-shadow: none !important;
 }
-.flek90-admin-page .button-primary:hover,
-.flek90-admin-page .button-primary:focus {
+.aftff-admin-page .button-primary:hover,
+.aftff-admin-page .button-primary:focus {
     background: #e6c300 !important; /* Darker gold */
     border-color: #cca700 !important; /* Slightly darker border */
-    color: var(--flek90-dark-text) !important;
+    color: var(--aftff-dark-text) !important;
 }
-.flek90-admin-page input[type="text"],
-.flek90-admin-page input[type="number"],
-.flek90-admin-page textarea {
+.aftff-admin-page input[type="text"],
+.aftff-admin-page input[type="number"],
+.aftff-admin-page textarea {
     background-color: #333940; /* Darker input background */
-    color: var(--flek90-light-text);
+    color: var(--aftff-light-text);
     border: 1px solid #555;
     padding: 6px 10px; /* Consistent padding */
     border-radius: 3px; /* Consistent border radius */
 }
-.flek90-admin-page input[type="text"]:focus,
-.flek90-admin-page input[type="number"]:focus,
-.flek90-admin-page textarea:focus,
-.flek90-admin-page select:focus { /* Added select:focus here */
-    border-color: var(--flek90-gold);
-    box-shadow: 0 0 0 1px var(--flek90-gold);
+.aftff-admin-page input[type="text"]:focus,
+.aftff-admin-page input[type="number"]:focus,
+.aftff-admin-page textarea:focus,
+.aftff-admin-page select:focus { /* Added select:focus here */
+    border-color: var(--aftff-gold);
+    box-shadow: 0 0 0 1px var(--aftff-gold);
 }
 
 /* Ensure select elements are clearly styled within the dark theme */
-.flek90-admin-page select {
+.aftff-admin-page select {
     background-color: #333940; /* Was #2E3338 */
-    color: #FFFFFF; /* Was var(--flek90-light-text) */
+    color: #FFFFFF; /* Was var(--aftff-light-text) */
     border: 1px solid #555;
     padding: 8px 12px; /* Slightly increased padding */
     border-radius: 3px;
@@ -113,25 +113,25 @@ body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-subme
 
 /* Styling for options within the select dropdown (browser dependent) */
 /* This is often not very customizable with CSS alone for all browsers */
-.flek90-admin-page select option {
+.aftff-admin-page select option {
     background-color: #2A2F34; /* Darker than the select box background */
-    color: #FFFFFF; /* Was var(--flek90-light-text) */
+    color: #FFFFFF; /* Was var(--aftff-light-text) */
     padding: 4px 8px; /* Add some padding to options if possible (browser dependent) */
 }
 
-.flek90-admin-page hr {
+.aftff-admin-page hr {
     border-color: #444; /* Darker hr */
 }
 
 /* Styles for Screenshot Gallery on Plugin Details Page */
-.flek90-admin-page .flek90-screenshots {
+.aftff-admin-page .aftff-screenshots {
     display: flex;
     flex-wrap: wrap;
     gap: 20px; /* Space between screenshot items */
     margin-top: 15px;
     margin-bottom: 20px;
 }
-.flek90-admin-page .flek90-screenshot {
+.aftff-admin-page .aftff-screenshot {
     flex: 1 1 300px; /* Allows items to grow/shrink, with a base width around 300px */
     border: 1px solid #444; /* Darker border, fitting the dark theme */
     padding: 15px;
@@ -140,29 +140,29 @@ body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-subme
     text-align: center;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
-.flek90-admin-page .flek90-screenshot img {
+.aftff-admin-page .aftff-screenshot img {
     max-width: 100%;
     height: auto;
     border: 1px solid #555; /* Border around the image itself */
     margin-bottom: 10px;
 }
-.flek90-admin-page .flek90-screenshot p { /* Caption style */
+.aftff-admin-page .aftff-screenshot p { /* Caption style */
     font-size: 0.9em;
-    color: var(--flek90-light-text); /* Uses the light text color from the theme */
+    color: var(--aftff-light-text); /* Uses the light text color from the theme */
     margin-top: 5px;
     margin-bottom: 0;
 }
 
-/* Styles for Admin Tabs within FleK90 Admin Pages */
-.flek90-admin-page .nav-tab-wrapper {
-    border-bottom: 1px solid var(--flek90-gold); /* Gold underline for the tab bar */
+/* Styles for Admin Tabs within AFTFF Admin Pages */
+.aftff-admin-page .nav-tab-wrapper {
+    border-bottom: 1px solid var(--aftff-gold); /* Gold underline for the tab bar */
     padding-left: 0; /* Align with content if needed */
     margin-bottom: 0; /* WordPress default is often 0, ensure it for clean look */
 }
 
-.flek90-admin-page .nav-tab {
+.aftff-admin-page .nav-tab {
     background-color: #383f47; /* Dark background for inactive tabs, slightly lighter than page */
-    color: var(--flek90-light-text); /* Light text for inactive tabs */
+    color: var(--aftff-light-text); /* Light text for inactive tabs */
     border: 1px solid #444; /* Border for inactive tabs */
     border-bottom: none; /* Remove bottom border for inactive tabs as wrapper has it */
     margin-right: 5px;
@@ -175,25 +175,25 @@ body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-subme
     transition: background-color 0.1s ease-in-out, color 0.1s ease-in-out; /* Smooth transition */
 }
 
-.flek90-admin-page .nav-tab:hover,
-.flek90-admin-page .nav-tab:focus {
+.aftff-admin-page .nav-tab:hover,
+.aftff-admin-page .nav-tab:focus {
     background-color: #4a525a; /* Lighter background on hover/focus for inactive tabs */
-    color: var(--flek90-gold); /* Gold text on hover/focus */
+    color: var(--aftff-gold); /* Gold text on hover/focus */
     border-color: #555; /* Slightly lighter border on hover */
     border-bottom: none;
 }
 
-.flek90-admin-page .nav-tab.nav-tab-active,
-.flek90-admin-page .nav-tab.nav-tab-active:hover,
-.flek90-admin-page .nav-tab.nav-tab-active:focus {
-    background-color: var(--flek90-gold); /* Gold background for the active tab */
-    color: var(--flek90-dark-text); /* Dark text for the active tab */
-    border-color: var(--flek90-gold) var(--flek90-gold) var(--flek90-gold); /* Gold border all around */
+.aftff-admin-page .nav-tab.nav-tab-active,
+.aftff-admin-page .nav-tab.nav-tab-active:hover,
+.aftff-admin-page .nav-tab.nav-tab-active:focus {
+    background-color: var(--aftff-gold); /* Gold background for the active tab */
+    color: var(--aftff-dark-text); /* Dark text for the active tab */
+    border-color: var(--aftff-gold) var(--aftff-gold) var(--aftff-gold); /* Gold border all around */
     /* To make the active tab appear "connected" to the content below,
        its bottom border is often set to the content area's background or made transparent.
        However, since the wrapper has the gold line, we make the active tab's bottom border also gold.
        If the content area below tabs has a different background, this might need adjustment.
-       Given .flek90-admin-page has var(--flek90-dark-bg), this should be fine.
+       Given .aftff-admin-page has var(--aftff-dark-bg), this should be fine.
     */
     font-weight: bold; /* Active tab text is bold */
 }
@@ -201,13 +201,13 @@ body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-subme
 /* Ensure the tab content div (if explicitly styled) has some space from the tabs */
 /* The PHP added inline style padding-top: 20px to a .tab-content div, which is good. */
 /* If .tab-content class is used for the div wrapping conditional content:
-.flek90-admin-page .tab-content {
+.aftff-admin-page .tab-content {
     padding-top: 20px;
 }
 */
 
 /* Styling for Code Example in Admin Settings Page */
-.flek90-admin-page pre {
+.aftff-admin-page pre {
     background-color: #1E1E1E; /* A common dark IDE background color, slightly different from page bg */
     color: #D4D4D4; /* Light gray text, common for dark themes */
     padding: 15px;
@@ -223,7 +223,7 @@ body.admin-color-fresh #adminmenu #toplevel_page_flek90_main_menu_slug .wp-subme
     display: block; /* Ensure it takes block-level for overflow-x to work as expected */
 }
 
-.flek90-admin-page pre code {
+.aftff-admin-page pre code {
     /* Most styling is on the <pre> tag.
        The <code> tag itself might not need much if <pre> handles font and color.
        However, you can ensure font family inheritance or specific color if needed. */

--- a/assets/js/aftff-color-picker-init.js
+++ b/assets/js/aftff-color-picker-init.js
@@ -1,4 +1,4 @@
 jQuery(document).ready(function($){
     // Initialize the WordPress color picker on the designated field
-    $('.flek90-color-picker-field').wpColorPicker();
+    $('.aftff-color-picker-field').wpColorPicker();
 });


### PR DESCRIPTION
- Removed load_plugin_textdomain() as it's handled by WP.org.
- Improved data sanitization clarity and fixed custom CSS saving.
- Ensured appropriate escaping for all outputs.
- Updated class name, option names, CSS/JS prefixes, and other programmatic identifiers to use a unique 'aftff_' prefix to prevent conflicts.
- Renamed asset files (CSS, JS) and updated references.